### PR TITLE
Support the :border style option

### DIFF
--- a/lib/puppet/functions/format/table.rb
+++ b/lib/puppet/functions/format/table.rb
@@ -52,7 +52,12 @@ Puppet::Functions.create_function(:'format::table') do
       t.rows = tdata[:rows].empty? ? [tdata[:rows]] : tdata[:rows]
       t.title = tdata[:title]
       t.headings = tdata[:head] if tdata[:head]
-      t.style = tdata[:style].transform_keys(&:to_sym) if tdata[:style]
+
+      unless tdata[:style].nil?
+        style = tdata[:style].transform_keys(&:to_sym)
+        style[:border] &&= style[:border].to_sym # This value is required to be a symbol
+        t.style = style
+      end
     end
     table.to_s
   rescue LoadError

--- a/types/tablestyle.pp
+++ b/types/tablestyle.pp
@@ -7,6 +7,7 @@
     padding_left => Optional[Integer],
     padding_right => Optional[Integer],
     border_x => Optional[String],
-    border_i => Optional[String]
+    border_i => Optional[String],
+    border => Optional[String]
   }
 ]


### PR DESCRIPTION
#### Pull Request (PR) description

This lets format print tables with unicode borders. Requires terminal-table gem version 3.x to work correctly.

Will become useful after https://github.com/puppetlabs/bolt/pull/3031 is merged and shipped.